### PR TITLE
fix: Make Vanta background truly global

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 import { ThemeProvider } from "next-themes";
+import VantaBackground from "@/components/VantaBackground";
 
 const queryClient = new QueryClient();
 
@@ -16,19 +17,22 @@ const App = () => (
     enableSystem
     disableTransitionOnChange
   >
-    <QueryClientProvider client={queryClient}>
-      <TooltipProvider>
-        <Toaster />
-        <Sonner />
-        <BrowserRouter>
-          <Routes>
-            <Route path="/" element={<Index />} />
-            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-            <Route path="*" element={<NotFound />} />
-          </Routes>
-        </BrowserRouter>
-      </TooltipProvider>
-    </QueryClientProvider>
+    <VantaBackground />
+    <main className="relative z-10">
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <Toaster />
+          <Sonner />
+          <BrowserRouter>
+            <Routes>
+              <Route path="/" element={<Index />} />
+              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </BrowserRouter>
+        </TooltipProvider>
+      </QueryClientProvider>
+    </main>
   </ThemeProvider>
 );
 

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -2,7 +2,7 @@ import VantaBackground from "@/components/VantaBackground";
 const About = () => {
   return (
     <>
-      <section id="about" className="py-20 bg-muted/30">
+      <section id="about" className="py-20">
         <div className="container mx-auto px-6">
           <div className="max-w-4xl mx-auto">
             <div className="text-center mb-12">

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -223,7 +223,7 @@ const Contact = () => {
                     required
                     value={formData.name}
                     onChange={handleChange}
-                    className="bg-background border-border focus:border-primary"
+                    className="border-border focus:border-primary"
                     placeholder="Your full name"
                   />
                 </div>
@@ -242,7 +242,7 @@ const Contact = () => {
                     required
                     value={formData.email}
                     onChange={handleChange}
-                    className="bg-background border-border focus:border-primary"
+                    className="border-border focus:border-primary"
                     placeholder="your.email@example.com"
                   />
                 </div>
@@ -260,7 +260,7 @@ const Contact = () => {
                     required
                     value={formData.message}
                     onChange={handleChange}
-                    className="bg-background border-border focus:border-primary min-h-[120px]"
+                    className="border-border focus:border-primary min-h-[120px]"
                     placeholder="Tell me about your project, opportunity, or just say hello..."
                   />
                 </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,7 +4,7 @@ const Footer = () => {
   const currentYear = new Date().getFullYear();
 
   return (
-    <footer className="bg-card border-t border-border py-12">
+    <footer className="border-t border-border py-12">
       <div className="container mx-auto px-6">
         <div className="max-w-6xl mx-auto">
           <div className="grid md:grid-cols-3 gap-8 mb-8">

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -61,7 +61,7 @@ const Projects = () => {
   ];
 
   return (
-    <section id="projects" className="py-20 bg-muted/30">
+    <section id="projects" className="py-20">
       <div className="container mx-auto px-6">
         <div className="max-w-6xl mx-auto">
           <div className="text-center mb-12">

--- a/src/index.css
+++ b/src/index.css
@@ -84,7 +84,7 @@
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply text-foreground;
     font-family: 'Inter', sans-serif;
     overflow-x: hidden;
   }
@@ -111,7 +111,6 @@
 
   /* Glass morphism effect */
   .glass {
-    background: rgba(255, 255, 255, 0.1);
     backdrop-filter: blur(10px);
     border: 1px solid rgba(255, 255, 255, 0.2);
   }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,11 +8,9 @@ import Skills from "@/components/Skills";
 import Contact from "@/components/Contact";
 import Footer from "@/components/Footer";
 import { ScrollAnimator } from "@/components/ScrollAnimator";
-import VantaBackground from "@/components/VantaBackground";
-
 const Index = () => {
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen">
       <Header />
       <Hero />
       <ScrollAnimator>
@@ -32,7 +30,6 @@ const Index = () => {
         <Contact />
       </ScrollAnimator>
       <Footer />
-      <VantaBackground />
     </div>
   );
 };


### PR DESCRIPTION
This commit removes background styles from all page sections, allowing the global Vanta background to be visible throughout the entire page.

- Removed `bg-muted/30` from About and Projects sections
- Removed `bg-card` from the Footer
- Made the `.glass` class background transparent
- Removed `bg-background` from form inputs